### PR TITLE
Add RAW mode to enable using GPIOs on other headers

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,3 +12,10 @@ This a modified version RPi.GPIO for Banana Pi. The original version for Raspber
 5. sudo python setup.py install  ==> generate GPIO.so
 
 The modified RPi.GPIO for Banana Pi is powered by LeMaker < http://www.lemaker.org/ > .
+
+This version supports a new addressing mode "RAW" which enables you to use any GPIO pin. Below is an example which sets PD10 (which is pin 29 on the LCD connector) to a high level.
+
+import RPi.GPIO as GPIO
+GPIO.setmode(GPIO.RAW)
+GPIO.setup(GPIO.PD+10, GPIO.OUT)
+GPIO.output(GPIO.PD+10, 1)

--- a/source/common.h
+++ b/source/common.h
@@ -23,6 +23,7 @@ SOFTWARE.
 #define MODE_UNKNOWN -1
 #define BOARD        10
 #define BCM          11
+#define MODE_RAW     12
 #define SERIAL       40
 #define SPI          41
 #define I2C          42

--- a/source/constants.c
+++ b/source/constants.c
@@ -61,6 +61,9 @@ void define_constants(PyObject *module)
    bcm = Py_BuildValue("i", BCM);
    PyModule_AddObject(module, "BCM", bcm);
 
+   raw = Py_BuildValue("i", MODE_RAW);
+   PyModule_AddObject(module, "RAW", raw);
+
    pud_off = Py_BuildValue("i", PUD_OFF + PY_PUD_CONST_OFFSET);
    PyModule_AddObject(module, "PUD_OFF", pud_off);
 
@@ -81,4 +84,14 @@ void define_constants(PyObject *module)
 
    version = Py_BuildValue("s", "0.5.8");
    PyModule_AddObject(module, "VERSION", version);
+
+   PyModule_AddObject(module, "PA", Py_BuildValue("i", 0));
+   PyModule_AddObject(module, "PB", Py_BuildValue("i", 32));
+   PyModule_AddObject(module, "PC", Py_BuildValue("i", 64));
+   PyModule_AddObject(module, "PD", Py_BuildValue("i", 96));
+   PyModule_AddObject(module, "PE", Py_BuildValue("i", 128));
+   PyModule_AddObject(module, "PF", Py_BuildValue("i", 160));
+   PyModule_AddObject(module, "PG", Py_BuildValue("i", 192));
+   PyModule_AddObject(module, "PH", Py_BuildValue("i", 224));
+   PyModule_AddObject(module, "PI", Py_BuildValue("i", 256));
 }

--- a/source/constants.h
+++ b/source/constants.h
@@ -34,6 +34,7 @@ PyObject *spi;
 PyObject *unknown;
 PyObject *board;
 PyObject *bcm;
+PyObject *raw;
 PyObject *pud_off;
 PyObject *pud_up;
 PyObject *pud_down;

--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -244,7 +244,7 @@ static PyObject *py_setmode(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   if (gpio_mode != BOARD && gpio_mode != BCM)
+   if (gpio_mode != BOARD && gpio_mode != BCM && gpio_mode != MODE_RAW)
    {
       PyErr_SetString(PyExc_ValueError, "An invalid mode was passed to setmode()");
       return NULL;
@@ -259,6 +259,8 @@ static unsigned int chan_from_gpio(unsigned int gpio)
 
    if (gpio_mode == BCM)
       return gpio;
+   if (gpio_mode == MODE_RAW)
+       return -1;  //Not supported in RAW mode as there is not always a mapping
    for (chan=1; chan<65; chan++)
       if (*(*pin_to_gpio+chan) == gpio)
          return chan;


### PR DESCRIPTION
With this implementation it is possible to use GPIOs on the LCD and CSI header. An example is given in the README file.
