### PR TITLE
Modify CPU check

### DIFF
--- a/source/cpuinfo.c
+++ b/source/cpuinfo.c
@@ -39,7 +39,7 @@ char *get_cpuinfo_revision(char *revision)
    while(!feof(fp)) {
       fgets(buffer, sizeof(buffer) , fp);
       sscanf(buffer, "Hardware  : %[^\n]", hardware);
-      if (strcmp(hardware, "sun7i") >= 0 ) {
+      if (strcmp(hardware, "sun7i") <= 0 ) {
          f_a20=1;
          rpi_found = 1;
 		 //printf("BAPI: Banana Pi!!\n");

--- a/source/cpuinfo.c
+++ b/source/cpuinfo.c
@@ -38,8 +38,8 @@ char *get_cpuinfo_revision(char *revision)
 
    while(!feof(fp)) {
       fgets(buffer, sizeof(buffer) , fp);
-      sscanf(buffer, "Hardware	: %s", hardware);
-      if (strcmp(hardware, "sun7i") == 0) {
+      sscanf(buffer, "Hardware  : %[^\n]", hardware);
+      if (strcmp(hardware, "sun7i") >= 0 ) {
          f_a20=1;
          rpi_found = 1;
 		 //printf("BAPI: Banana Pi!!\n");

--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -658,7 +658,7 @@ PyMODINIT_FUNC initGPIO(void)
 
    // detect board revision and set up accordingly
    revision = get_rpi_revision();
-D	printf("BAPI: revision(%d)\n",revision);
+//D	printf("BAPI: revision(%d)\n",revision);
    if (revision == -1)
    {
       PyErr_SetString(PyExc_RuntimeError, "This module can only be run on a Raspberry Pi!");


### PR DESCRIPTION
Handles the difference in string values in /proc/cpuinfo across various kernel versions by locating the "sun7i" anywhere in the hardware string. Examples:

-- Linux lemaker 3.4.103 #1 SMP PREEMPT Thu Dec 18 13:07:12 CST 2014 armv7l GNU/Linux
Hardware    : sun7i

-- Linux bananapi 4.2.3-sunxi #2 SMP Sun Oct 11 14:12:18 CEST 2015 armv7l GNU/Linux
Hardware    : Allwinner sun7i (A20) Family
