### PR TITLE
Update cpuinfo.c

### DIFF
--- a/source/cpuinfo.c
+++ b/source/cpuinfo.c
@@ -39,7 +39,7 @@ char *get_cpuinfo_revision(char *revision)
 	while(!feof(fp)) {
 		fgets(buffer, sizeof(buffer) , fp);
 		sscanf(buffer, "Hardware	: %s", hardware);
-		if (strcmp(hardware, "sun7i") == 0) {
+		if (strstr(hardware, "sun7i") == 0) {
 			f_a20=1;
 			rpi_found = 1;
 			//printf("BAPI: Banana Pi!!\n");


### PR DESCRIPTION
Fix from http://forum.lemaker.org/forum.php?mod=redirect&goto=findpost&ptid=11831&pid=91959 by user DerOptiker.

Here is output from my Banana Pro:

```
$ sudo cat /proc/cpuinfo | grep Hardware
Hardware        : Allwinner sun7i (A20) Family
```

Tested with todays branch on Python2.7:

```
$ python
Python 2.7.11 (default, Dec 11 2015, 05:34:18) 
[GCC 5.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import RPi.GPIO as GPIO
BAPI: revision(2)
>>> 
```

Tested with todays branch on Python3:

```
$ python   
Python 3.5.1 (default, Dec 11 2015, 05:35:45) 
[GCC 5.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import RPi.GPIO as GPIO
BAPI: revision(2)
>>> 
```

Tests done on Arch ARM.

Again, I did not debug this, this was solved 1 year ago in the forum. About time someone writes a pull request. ;)
